### PR TITLE
added dynamic port retrieval for schema registry if port is 0

### DIFF
--- a/src/test/scala/net/manub/embeddedkafka/schemaregistry/EmbeddedKafkaTraitSpec.scala
+++ b/src/test/scala/net/manub/embeddedkafka/schemaregistry/EmbeddedKafkaTraitSpec.scala
@@ -14,7 +14,16 @@ class EmbeddedKafkaTraitSpec
       }
     }
   }
+
   "the withRunningKafkaOnFoundPort method" should {
+
+    "start a Schema Registry server on an available port if 0" in {
+      val userDefinedConfig: EmbeddedKafkaConfig =
+        EmbeddedKafkaConfig(schemaRegistryPort = 0)
+      withRunningKafkaOnFoundPort(userDefinedConfig) { actualConfig =>
+        schemaRegistryIsAvailable(actualConfig.schemaRegistryPort)
+      }
+    }
 
     "start and stop Kafka, Zookeeper, and Schema Registry successfully on non-zero ports" in {
       val userDefinedConfig =


### PR DESCRIPTION
If the user defined schema registry port is 0 an available one is used