### PR TITLE
bump Confluent to 5.5.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,15 @@ Versions match the version of Confluent Schema Registry they're built against.
 
 ## How to use
 
-* In your `build.sbt` file add the following resolver: `resolvers += "confluent" at "https://packages.confluent.io/maven/"`
+* In your `build.sbt` file add the following resolvers:
+
+```scala
+resolvers ++= Seq(
+  "confluent" at "https://packages.confluent.io/maven/",
+  "jitpack" at "https://jitpack.io"
+)
+```
+
 * In your `build.sbt` file add the following dependency (replace `x.x.x` with the appropriate version): `"io.github.embeddedkafka" %% "embedded-kafka-schema-registry" % "x.x.x" % Test`
 * Have your class extend the `EmbeddedKafka` trait (from the `net.manub.embeddedkafka.schemaregistry` package).
 * Enclose the code that needs a running instance of Kafka within the `withRunningKafka` closure.

--- a/build.sbt
+++ b/build.sbt
@@ -1,7 +1,7 @@
 import sbtrelease.Version
 
 val embeddedKafkaVersion = "2.5.0"
-val confluentVersion = "5.4.1"
+val confluentVersion = "5.5.0"
 
 lazy val publishSettings = Seq(
   licenses += ("MIT", url("https://opensource.org/licenses/MIT")),
@@ -47,11 +47,18 @@ lazy val releaseSettings = Seq(
   releaseCrossBuild := true
 )
 
+lazy val confluentResolvers = Seq(
+  "confluent" at "https://packages.confluent.io/maven/",
+  // Since v5.5.0
+  "jitpack" at "https://jitpack.io"
+)
+
 lazy val commonSettings = Seq(
   organization := "io.github.embeddedkafka",
   scalaVersion := "2.12.10",
   crossScalaVersions := Seq("2.12.10"),
   homepage := Some(url("https://github.com/embeddedkafka/embedded-kafka-schema-registry")),
+  resolvers ++= confluentResolvers,
   parallelExecution in Test := false,
   logBuffered in Test := false,
   fork in Test := true,
@@ -89,7 +96,3 @@ lazy val root = (project in file("."))
   .settings(commonSettings: _*)
   .settings(commonLibrarySettings)
   .settings(releaseSettings: _*)
-  .settings(resolvers ++= Seq(
-    "confluent" at "https://packages.confluent.io/maven/",
-    Resolver.sonatypeRepo("snapshots")
-  ))


### PR DESCRIPTION
add custom resolver for newly-introduced JSON dependency and remove Sonatype snapshot resolver