### PR TITLE
remove most of the deprecated Avro references

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,9 +54,11 @@ class MySpec extends AnyWordSpecLike with Matchers with EmbeddedKafka {
 
 * In-memory Zookeeper, Kafka, and Schema Registry will be instantiated respectively on port 6000, 6001, and 6002 and automatically shutdown at the end of the test.
 
-## Utility methods
+## ~~Utility methods~~
 
-`net.manub.embeddedkafka.schemaregistry.avro.AvroSerdes` provides utility methods for building Avro Serdes.
+~~.`net.manub.embeddedkafka.schemaregistry.avro.AvroSerdes` provides utility methods for building Avro Serdes.~~
+
+Now that Schema Registry supports more than one serialization format, Avro-related classes will be removed in the near future.
 
 ## Using streams
 

--- a/build.sbt
+++ b/build.sbt
@@ -81,8 +81,7 @@ lazy val commonSettings = Seq(
 // They tend to evict Apache's since their version is greater
 lazy val confluentArtifacts = Seq(
   "io.confluent" % "kafka-avro-serializer" % confluentVersion,
-  "io.confluent" % "kafka-schema-registry" % confluentVersion,
-  "io.confluent" % "kafka-schema-registry" % confluentVersion classifier "tests"
+  "io.confluent" % "kafka-schema-registry" % confluentVersion
 ).map(_ excludeAll ExclusionRule().withOrganization("org.apache.kafka"))
 
 lazy val commonLibrarySettings = libraryDependencies ++= Seq(

--- a/src/main/scala/net.manub.embeddedkafka/schemaregistry/Codecs.scala
+++ b/src/main/scala/net.manub.embeddedkafka/schemaregistry/Codecs.scala
@@ -1,0 +1,14 @@
+package net.manub.embeddedkafka.schemaregistry
+
+import org.apache.kafka.clients.consumer.ConsumerRecord
+
+object Codecs {
+  implicit def stringKeyGenericValueCrDecoder[V]
+      : ConsumerRecord[String, V] => (String, V) =
+    cr => (cr.key, cr.value)
+  implicit def genericValueCrDecoder[V]: ConsumerRecord[String, V] => V =
+    _.value
+  implicit def stringKeyGenericValueTopicCrDecoder[V]
+      : ConsumerRecord[String, V] => (String, String, V) =
+    cr => (cr.topic, cr.key, cr.value)
+}

--- a/src/main/scala/net.manub.embeddedkafka/schemaregistry/EmbeddedKafka.scala
+++ b/src/main/scala/net.manub.embeddedkafka/schemaregistry/EmbeddedKafka.scala
@@ -35,21 +35,21 @@ trait EmbeddedKafka
         config.customBrokerProperties,
         kafkaLogsDir
       )
+    val actualKafkaPort = EmbeddedKafka.kafkaPort(broker)
     val restApp = startSchemaRegistry(
       config.schemaRegistryPort,
-      actualZkPort,
-      config.compatibilityLevel
+      actualKafkaPort,
+      config.customSchemaRegistryProperties
     )
-    val actualSchemaRegistryPort = restApp.restServer.getURI.getPort
 
     val configWithUsedPorts = EmbeddedKafkaConfig(
-      EmbeddedKafka.kafkaPort(broker),
+      actualKafkaPort,
       actualZkPort,
-      actualSchemaRegistryPort,
-      config.compatibilityLevel,
+      EmbeddedKafka.schemaRegistryPort(restApp),
       config.customBrokerProperties,
       config.customProducerProperties,
-      config.customConsumerProperties
+      config.customConsumerProperties,
+      config.customSchemaRegistryProperties
     )
 
     try {
@@ -79,10 +79,10 @@ object EmbeddedKafka
       config.kafkaPort,
       zookeeperPort(factory),
       config.schemaRegistryPort,
-      config.compatibilityLevel,
       config.customBrokerProperties,
       config.customProducerProperties,
-      config.customConsumerProperties
+      config.customConsumerProperties,
+      config.customSchemaRegistryProperties
     )
 
     val kafkaBroker = startKafka(configWithUsedZooKeeperPort, kafkaLogsDir)
@@ -90,8 +90,8 @@ object EmbeddedKafka
     val restApp = EmbeddedSR(
       startSchemaRegistry(
         configWithUsedZooKeeperPort.schemaRegistryPort,
-        configWithUsedZooKeeperPort.zooKeeperPort,
-        configWithUsedZooKeeperPort.compatibilityLevel
+        EmbeddedKafka.kafkaPort(kafkaBroker),
+        configWithUsedZooKeeperPort.customSchemaRegistryProperties
       )
     )
 

--- a/src/main/scala/net.manub.embeddedkafka/schemaregistry/EmbeddedKafka.scala
+++ b/src/main/scala/net.manub.embeddedkafka/schemaregistry/EmbeddedKafka.scala
@@ -16,12 +16,12 @@ trait EmbeddedKafka
   override private[embeddedkafka] def baseConsumerConfig(
       implicit config: EmbeddedKafkaConfig
   ): Map[String, Object] =
-    defaultConsumerConfig ++ configForSchemaRegistry ++ config.customConsumerProperties
+    defaultConsumerConfig ++ config.customConsumerProperties
 
   override private[embeddedkafka] def baseProducerConfig(
       implicit config: EmbeddedKafkaConfig
   ): Map[String, Object] =
-    defaultProducerConf ++ configForSchemaRegistry ++ config.customProducerProperties
+    defaultProducerConf ++ config.customProducerProperties
 
   override private[embeddedkafka] def withRunningServers[T](
       config: EmbeddedKafkaConfig,
@@ -38,7 +38,7 @@ trait EmbeddedKafka
     val restApp = startSchemaRegistry(
       config.schemaRegistryPort,
       actualZkPort,
-      config.avroCompatibilityLevel
+      config.compatibilityLevel
     )
     val actualSchemaRegistryPort = restApp.restServer.getURI.getPort
 
@@ -46,7 +46,7 @@ trait EmbeddedKafka
       EmbeddedKafka.kafkaPort(broker),
       actualZkPort,
       actualSchemaRegistryPort,
-      config.avroCompatibilityLevel,
+      config.compatibilityLevel,
       config.customBrokerProperties,
       config.customProducerProperties,
       config.customConsumerProperties
@@ -79,7 +79,7 @@ object EmbeddedKafka
       config.kafkaPort,
       zookeeperPort(factory),
       config.schemaRegistryPort,
-      config.avroCompatibilityLevel,
+      config.compatibilityLevel,
       config.customBrokerProperties,
       config.customProducerProperties,
       config.customConsumerProperties
@@ -91,7 +91,7 @@ object EmbeddedKafka
       startSchemaRegistry(
         configWithUsedZooKeeperPort.schemaRegistryPort,
         configWithUsedZooKeeperPort.zooKeeperPort,
-        configWithUsedZooKeeperPort.avroCompatibilityLevel
+        configWithUsedZooKeeperPort.compatibilityLevel
       )
     )
 

--- a/src/main/scala/net.manub.embeddedkafka/schemaregistry/avro/AvroSerdes.scala
+++ b/src/main/scala/net.manub.embeddedkafka/schemaregistry/avro/AvroSerdes.scala
@@ -1,12 +1,10 @@
 package net.manub.embeddedkafka.schemaregistry.avro
 
 import io.confluent.kafka.serializers.{
+  AbstractKafkaSchemaSerDeConfig,
+  KafkaAvroDeserializerConfig,
   KafkaAvroDeserializer => ConfluentKafkaAvroDeserializer,
   KafkaAvroSerializer => ConfluentKafkaAvroSerializer
-}
-import net.manub.embeddedkafka.schemaregistry.EmbeddedKafka.{
-  configForSchemaRegistry,
-  specificAvroReaderConfigForSchemaRegistry
 }
 import net.manub.embeddedkafka.schemaregistry.EmbeddedKafkaConfig
 import org.apache.avro.generic.GenericRecord
@@ -15,33 +13,49 @@ import org.apache.kafka.common.serialization.{Serde, Serdes}
 
 import scala.collection.JavaConverters._
 
+@deprecated(
+  "Avro-related classes will be removed soon",
+  since = "5.5.0"
+)
 object AvroSerdes {
+
+  protected def configForSchemaRegistry(
+      implicit config: EmbeddedKafkaConfig
+  ): Map[String, Object] =
+    Map(
+      AbstractKafkaSchemaSerDeConfig.SCHEMA_REGISTRY_URL_CONFIG -> s"http://localhost:${config.schemaRegistryPort}"
+    )
+
+  protected def specificAvroReaderConfigForSchemaRegistry(
+      implicit config: EmbeddedKafkaConfig
+  ): Map[String, Object] =
+    configForSchemaRegistry ++ Map(
+      KafkaAvroDeserializerConfig.SPECIFIC_AVRO_READER_CONFIG -> true.toString
+    )
 
   def specific[T <: SpecificRecord](
       isKey: Boolean = false,
       extraConfig: Map[String, Object] = Map.empty
   )(
       implicit config: EmbeddedKafkaConfig
-  ): Serde[T] = {
+  ): Serde[T] =
     serdeFrom[T](
       configForSchemaRegistry ++ extraConfig,
       specificAvroReaderConfigForSchemaRegistry ++ extraConfig, //need this to support SpecificRecord
       isKey
     )
-  }
 
   def generic(
       isKey: Boolean = false,
       extraConfig: Map[String, Object] = Map.empty
   )(
       implicit config: EmbeddedKafkaConfig
-  ): Serde[GenericRecord] = {
+  ): Serde[GenericRecord] =
     serdeFrom[GenericRecord](
       configForSchemaRegistry ++ extraConfig,
       configForSchemaRegistry ++ extraConfig,
       isKey
     )
-  }
 
   private def serdeFrom[T](
       serConfig: Map[String, Object],

--- a/src/main/scala/net.manub.embeddedkafka/schemaregistry/avro/Codecs.scala
+++ b/src/main/scala/net.manub.embeddedkafka/schemaregistry/avro/Codecs.scala
@@ -4,6 +4,10 @@ import org.apache.avro.generic.GenericRecord
 import org.apache.avro.specific.SpecificRecord
 import org.apache.kafka.clients.consumer.ConsumerRecord
 
+@deprecated(
+  "Avro-related classes will be removed soon",
+  since = "5.5.0"
+)
 object Codecs {
   implicit def stringKeyAvroValueCrDecoder[V <: SpecificRecord]
       : ConsumerRecord[String, V] => (String, V) =

--- a/src/main/scala/net.manub.embeddedkafka/schemaregistry/config.scala
+++ b/src/main/scala/net.manub.embeddedkafka/schemaregistry/config.scala
@@ -1,23 +1,22 @@
 package net.manub.embeddedkafka.schemaregistry
 
-import io.confluent.kafka.schemaregistry.CompatibilityLevel
 import net.manub.embeddedkafka.{
   EmbeddedKafkaConfig => OriginalEmbeddedKafkaConfig
 }
 
 trait EmbeddedKafkaConfig extends OriginalEmbeddedKafkaConfig {
   def schemaRegistryPort: Int
-  def compatibilityLevel: CompatibilityLevel
+  def customSchemaRegistryProperties: Map[String, String]
 }
 
 case class EmbeddedKafkaConfigImpl(
     kafkaPort: Int,
     zooKeeperPort: Int,
     schemaRegistryPort: Int,
-    compatibilityLevel: CompatibilityLevel,
     customBrokerProperties: Map[String, String],
     customProducerProperties: Map[String, String],
-    customConsumerProperties: Map[String, String]
+    customConsumerProperties: Map[String, String],
+    customSchemaRegistryProperties: Map[String, String]
 ) extends EmbeddedKafkaConfig {
   override val numberOfThreads: Int = 3
 }
@@ -31,18 +30,18 @@ object EmbeddedKafkaConfig {
       kafkaPort: Int = OriginalEmbeddedKafkaConfig.defaultKafkaPort,
       zooKeeperPort: Int = OriginalEmbeddedKafkaConfig.defaultZookeeperPort,
       schemaRegistryPort: Int = defaultSchemaRegistryPort,
-      compatibilityLevel: CompatibilityLevel = CompatibilityLevel.NONE,
       customBrokerProperties: Map[String, String] = Map.empty,
       customProducerProperties: Map[String, String] = Map.empty,
-      customConsumerProperties: Map[String, String] = Map.empty
+      customConsumerProperties: Map[String, String] = Map.empty,
+      customSchemaRegistryProperties: Map[String, String] = Map.empty
   ): EmbeddedKafkaConfig =
     EmbeddedKafkaConfigImpl(
       kafkaPort,
       zooKeeperPort,
       schemaRegistryPort,
-      compatibilityLevel,
       customBrokerProperties,
       customProducerProperties,
-      customConsumerProperties
+      customConsumerProperties,
+      customSchemaRegistryProperties
     )
 }

--- a/src/main/scala/net.manub.embeddedkafka/schemaregistry/config.scala
+++ b/src/main/scala/net.manub.embeddedkafka/schemaregistry/config.scala
@@ -1,20 +1,20 @@
 package net.manub.embeddedkafka.schemaregistry
 
-import io.confluent.kafka.schemaregistry.avro.AvroCompatibilityLevel
+import io.confluent.kafka.schemaregistry.CompatibilityLevel
 import net.manub.embeddedkafka.{
   EmbeddedKafkaConfig => OriginalEmbeddedKafkaConfig
 }
 
 trait EmbeddedKafkaConfig extends OriginalEmbeddedKafkaConfig {
   def schemaRegistryPort: Int
-  def avroCompatibilityLevel: AvroCompatibilityLevel
+  def compatibilityLevel: CompatibilityLevel
 }
 
 case class EmbeddedKafkaConfigImpl(
     kafkaPort: Int,
     zooKeeperPort: Int,
     schemaRegistryPort: Int,
-    avroCompatibilityLevel: AvroCompatibilityLevel,
+    compatibilityLevel: CompatibilityLevel,
     customBrokerProperties: Map[String, String],
     customProducerProperties: Map[String, String],
     customConsumerProperties: Map[String, String]
@@ -31,8 +31,7 @@ object EmbeddedKafkaConfig {
       kafkaPort: Int = OriginalEmbeddedKafkaConfig.defaultKafkaPort,
       zooKeeperPort: Int = OriginalEmbeddedKafkaConfig.defaultZookeeperPort,
       schemaRegistryPort: Int = defaultSchemaRegistryPort,
-      avroCompatibilityLevel: AvroCompatibilityLevel =
-        AvroCompatibilityLevel.NONE,
+      compatibilityLevel: CompatibilityLevel = CompatibilityLevel.NONE,
       customBrokerProperties: Map[String, String] = Map.empty,
       customProducerProperties: Map[String, String] = Map.empty,
       customConsumerProperties: Map[String, String] = Map.empty
@@ -41,7 +40,7 @@ object EmbeddedKafkaConfig {
       kafkaPort,
       zooKeeperPort,
       schemaRegistryPort,
-      avroCompatibilityLevel,
+      compatibilityLevel,
       customBrokerProperties,
       customProducerProperties,
       customConsumerProperties

--- a/src/main/scala/net.manub.embeddedkafka/schemaregistry/ops/SchemaRegistryOps.scala
+++ b/src/main/scala/net.manub.embeddedkafka/schemaregistry/ops/SchemaRegistryOps.scala
@@ -3,12 +3,7 @@ package net.manub.embeddedkafka.schemaregistry.ops
 import java.net.ServerSocket
 import java.util.Properties
 
-import io.confluent.kafka.schemaregistry.RestApp
-import io.confluent.kafka.schemaregistry.avro.AvroCompatibilityLevel
-import io.confluent.kafka.serializers.{
-  AbstractKafkaAvroSerDeConfig,
-  KafkaAvroDeserializerConfig
-}
+import io.confluent.kafka.schemaregistry.{CompatibilityLevel, RestApp}
 import net.manub.embeddedkafka.EmbeddedServer
 import net.manub.embeddedkafka.ops.RunningServersOps
 import net.manub.embeddedkafka.schemaregistry.{EmbeddedKafkaConfig, EmbeddedSR}
@@ -20,40 +15,17 @@ import net.manub.embeddedkafka.schemaregistry.{EmbeddedKafkaConfig, EmbeddedSR}
 trait SchemaRegistryOps {
 
   /**
-    * @param config an implicit [[EmbeddedKafkaConfig]].
-    * @return a map of configuration to grant Schema Registry support
-    */
-  protected[embeddedkafka] def configForSchemaRegistry(
-      implicit config: EmbeddedKafkaConfig
-  ): Map[String, Object] =
-    Map(
-      AbstractKafkaAvroSerDeConfig.SCHEMA_REGISTRY_URL_CONFIG -> s"http://localhost:${config.schemaRegistryPort}"
-    )
-
-  /**
-    * @param config an implicit [[EmbeddedKafkaConfig]].
-    * @return a map of Kafka Consumer configuration to grant Schema Registry support
-    */
-  protected[embeddedkafka] def specificAvroReaderConfigForSchemaRegistry(
-      implicit config: EmbeddedKafkaConfig
-  ): Map[String, Object] =
-    configForSchemaRegistry ++ Map(
-      KafkaAvroDeserializerConfig.SPECIFIC_AVRO_READER_CONFIG -> true.toString
-    )
-
-  /**
     * Starts a Schema Registry instance.
     *
-    * @param schemaRegistryPort     the port to run Schema Registry on, if 0 an available port will be used
-    * @param zooKeeperPort          the port ZooKeeper is running on
-    * @param avroCompatibilityLevel the default [[AvroCompatibilityLevel]] of schemas
-    * @param properties             additional [[Properties]]
+    * @param schemaRegistryPort the port to run Schema Registry on, if 0 an available port will be used
+    * @param zooKeeperPort      the port ZooKeeper is running on
+    * @param compatibilityLevel the schema compatibility level
+    * @param properties         additional [[Properties]]
     */
   def startSchemaRegistry(
       schemaRegistryPort: Int,
       zooKeeperPort: Int,
-      avroCompatibilityLevel: AvroCompatibilityLevel =
-        AvroCompatibilityLevel.NONE,
+      compatibilityLevel: CompatibilityLevel = CompatibilityLevel.NONE,
       properties: Properties = new Properties
   ): RestApp = {
     def findAvailablePort: Int = {
@@ -70,7 +42,7 @@ trait SchemaRegistryOps {
       actualSchemaRegistryPort,
       s"localhost:$zooKeeperPort",
       "_schemas",
-      avroCompatibilityLevel.name,
+      compatibilityLevel.name,
       properties
     )
     server.start()
@@ -92,7 +64,7 @@ trait RunningSchemaRegistryOps {
       startSchemaRegistry(
         config.schemaRegistryPort,
         config.zooKeeperPort,
-        config.avroCompatibilityLevel
+        config.compatibilityLevel
       )
     )
     runningServers.add(restApp)

--- a/src/main/scala/net.manub.embeddedkafka/schemaregistry/servers.scala
+++ b/src/main/scala/net.manub.embeddedkafka/schemaregistry/servers.scala
@@ -2,7 +2,7 @@ package net.manub.embeddedkafka.schemaregistry
 
 import java.nio.file.Path
 
-import io.confluent.kafka.schemaregistry.RestApp
+import io.confluent.kafka.schemaregistry.rest.SchemaRegistryRestApplication
 import kafka.server.KafkaServer
 import net.manub.embeddedkafka.{
   EmbeddedServer,
@@ -17,7 +17,8 @@ import scala.reflect.io.Directory
   *
   * @param app the Schema Registry app.
   */
-case class EmbeddedSR(app: RestApp) extends EmbeddedServer {
+case class EmbeddedSR(app: SchemaRegistryRestApplication)
+    extends EmbeddedServer {
 
   /**
     * Shuts down the app.

--- a/src/main/scala/net.manub.embeddedkafka/schemaregistry/streams/EmbeddedStreamsConfigImpl.scala
+++ b/src/main/scala/net.manub.embeddedkafka/schemaregistry/streams/EmbeddedStreamsConfigImpl.scala
@@ -1,9 +1,6 @@
 package net.manub.embeddedkafka.schemaregistry.streams
 
-import net.manub.embeddedkafka.schemaregistry.{
-  EmbeddedKafkaConfig,
-  EmbeddedKafka
-}
+import net.manub.embeddedkafka.schemaregistry.EmbeddedKafkaConfig
 import net.manub.embeddedkafka.streams.EmbeddedStreamsConfig
 
 final class EmbeddedStreamsConfigImpl
@@ -11,5 +8,5 @@ final class EmbeddedStreamsConfigImpl
   override def config(streamName: String, extraConfig: Map[String, AnyRef])(
       implicit kafkaConfig: EmbeddedKafkaConfig
   ): Map[String, AnyRef] =
-    baseStreamConfig(streamName) ++ EmbeddedKafka.specificAvroReaderConfigForSchemaRegistry ++ extraConfig
+    baseStreamConfig(streamName) ++ extraConfig
 }

--- a/src/test/scala/net/manub/embeddedkafka/schemaregistry/EmbeddedKafkaTraitSpec.scala
+++ b/src/test/scala/net/manub/embeddedkafka/schemaregistry/EmbeddedKafkaTraitSpec.scala
@@ -1,11 +1,8 @@
 package net.manub.embeddedkafka.schemaregistry
 
-import io.confluent.kafka.schemaregistry.avro.AvroCompatibilityLevel
+import io.confluent.kafka.schemaregistry.CompatibilityLevel
 import net.manub.embeddedkafka.schemaregistry.EmbeddedKafka._
-import net.manub.embeddedkafka.schemaregistry.EmbeddedKafkaSpecSupport.{
-  Available,
-  NotAvailable
-}
+import net.manub.embeddedkafka.schemaregistry.EmbeddedKafkaSpecSupport.{Available, NotAvailable}
 
 class EmbeddedKafkaTraitSpec extends EmbeddedKafkaSpecSupport {
   "the withRunningKafka method" should {
@@ -34,7 +31,7 @@ class EmbeddedKafkaTraitSpec extends EmbeddedKafkaSpecSupport {
           kafkaPort = 12345,
           zooKeeperPort = 12346,
           schemaRegistryPort = 12347,
-          avroCompatibilityLevel = AvroCompatibilityLevel.NONE
+          compatibilityLevel = CompatibilityLevel.NONE
         )
 
       val actualConfig = withRunningKafkaOnFoundPort(userDefinedConfig) {

--- a/src/test/scala/net/manub/embeddedkafka/schemaregistry/EmbeddedKafkaTraitSpec.scala
+++ b/src/test/scala/net/manub/embeddedkafka/schemaregistry/EmbeddedKafkaTraitSpec.scala
@@ -1,8 +1,10 @@
 package net.manub.embeddedkafka.schemaregistry
 
-import io.confluent.kafka.schemaregistry.CompatibilityLevel
 import net.manub.embeddedkafka.schemaregistry.EmbeddedKafka._
-import net.manub.embeddedkafka.schemaregistry.EmbeddedKafkaSpecSupport.{Available, NotAvailable}
+import net.manub.embeddedkafka.schemaregistry.EmbeddedKafkaSpecSupport.{
+  Available,
+  NotAvailable
+}
 
 class EmbeddedKafkaTraitSpec extends EmbeddedKafkaSpecSupport {
   "the withRunningKafka method" should {
@@ -30,8 +32,7 @@ class EmbeddedKafkaTraitSpec extends EmbeddedKafkaSpecSupport {
         EmbeddedKafkaConfig(
           kafkaPort = 12345,
           zooKeeperPort = 12346,
-          schemaRegistryPort = 12347,
-          compatibilityLevel = CompatibilityLevel.NONE
+          schemaRegistryPort = 12347
         )
 
       val actualConfig = withRunningKafkaOnFoundPort(userDefinedConfig) {

--- a/src/test/scala/net/manub/embeddedkafka/schemaregistry/TestAvroClass.scala
+++ b/src/test/scala/net/manub/embeddedkafka/schemaregistry/TestAvroClass.scala
@@ -1,7 +1,4 @@
-/**
-  * Cloned from embeddedkafka project
-  */
-package net.manub.embeddedkafka
+package net.manub.embeddedkafka.schemaregistry
 
 import org.apache.avro.specific.SpecificRecordBase
 import org.apache.avro.{AvroRuntimeException, Schema}
@@ -28,14 +25,14 @@ case class TestAvroClass(var name: String) extends SpecificRecordBase {
 
 object TestAvroClass {
   val SCHEMA$ =
-    (new Schema.Parser).parse("""
-                                |{"namespace": "example",
-                                | "type": "record",
-                                | "namespace": "net.manub.embeddedkafka",
-                                | "name": "TestAvroClass",
-                                | "fields": [
-                                |     {"name": "name", "type": "string"}
-                                | ]
-                                |}
-                              """.stripMargin)
+    (new Schema.Parser)
+      .parse("""
+                |{"namespace": "net.manub.embeddedkafka.schemaregistry",
+                | "type": "record",
+                | "name": "TestAvroClass",
+                | "fields": [
+                |   {"name": "name", "type": "string"}
+                | ]
+                |}
+              """.stripMargin)
 }

--- a/src/test/scala/net/manub/embeddedkafka/schemaregistry/streams/ExampleKafkaStreamsSpec.scala
+++ b/src/test/scala/net/manub/embeddedkafka/schemaregistry/streams/ExampleKafkaStreamsSpec.scala
@@ -1,6 +1,5 @@
 package net.manub.embeddedkafka.schemaregistry.streams
 
-import io.confluent.kafka.schemaregistry.CompatibilityLevel
 import io.confluent.kafka.serializers.{
   AbstractKafkaSchemaSerDeConfig,
   KafkaAvroDeserializer,
@@ -30,8 +29,7 @@ class ExampleKafkaStreamsSpec extends AnyWordSpec with Matchers {
     EmbeddedKafkaConfig(
       kafkaPort = 7000,
       zooKeeperPort = 7001,
-      schemaRegistryPort = 7002,
-      compatibilityLevel = CompatibilityLevel.FULL
+      schemaRegistryPort = 7002
     )
 
   private def avroSerde[T](props: Map[String, AnyRef]): Serde[T] = {


### PR DESCRIPTION
skip providing Schema Registry props to producers and consumers (they don't need it anyway)