### PR TITLE
Apply customProperties after the predetermined ones

### DIFF
--- a/embedded-kafka-schema-registry/src/main/scala/io/github/embeddedkafka/schemaregistry/ops/SchemaRegistryOps.scala
+++ b/embedded-kafka-schema-registry/src/main/scala/io/github/embeddedkafka/schemaregistry/ops/SchemaRegistryOps.scala
@@ -33,10 +33,10 @@ trait SchemaRegistryOps {
     val actualSchemaRegistryPort =
       if (schemaRegistryPort == 0) findAvailablePort else schemaRegistryPort
 
-    val restAppProperties = customProperties ++ Map(
+    val restAppProperties = Map(
       RestConfig.LISTENERS_CONFIG                              -> s"http://localhost:$actualSchemaRegistryPort",
       SchemaRegistryConfig.KAFKASTORE_BOOTSTRAP_SERVERS_CONFIG -> s"localhost:$kafkaPort"
-    )
+    ) ++ customProperties
 
     val restApp = new SchemaRegistryRestApplication(
       new SchemaRegistryConfig(map2Properties(restAppProperties))


### PR DESCRIPTION
A very minor change with a very uncommon use-case in mind, but hear me out please.

For starting up the Kafka broker itself, the custom properties which can be supplied by the user are already applied after the ones predetermined by the library as can be seen in the source [here](https://github.com/embeddedkafka/embedded-kafka/blob/1ecd7f75e603329f7a4f732c1425c0221ff2230b/embedded-kafka/src/main/scala/io/github/embeddedkafka/ops/kafkaOps.scala#L50).

So in order to be devious and hide my use case I would argue that this change simply makes the two more aligned which is great.

To reveal why I am actually interested in this: I play around with Kafka a lot and quite often it is useful to have things run in Docker Compose for presentation purposes or just for being able to toy around locally. Embedded Kafka is great for this as it allows you to create topics at startup of the broker and hence does not require you to run some script after. And Embedded Kafka is already something you can build into a Docker image easily as it applies the custom properties after everything predefined (see link to source above) and hence let's you set up the listeners such that they work in a container context. For Schema Registry so far this is not done and because the listeners config is using localhost there is no way to make Schema Registry available in a container context. I would like to change that.

If there are no considerations specifically against this I'd love to see this merged.