### PR TITLE
bump embedded-kafka and Confluent platform to 3.2.0 and 7.2.0 respectively

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -13,8 +13,8 @@ object Dependencies {
   object Versions {
     val Scala             = "2.13.8"
     val Scala212          = "2.12.16"
-    val EmbeddedKafka     = "3.1.0"
-    val ConfluentPlatform = "7.1.2"
+    val EmbeddedKafka     = "3.2.0"
+    val ConfluentPlatform = "7.2.0"
     val Slf4j             = "1.7.36"
     val ScalaTest         = "3.2.12"
   }


### PR DESCRIPTION
Supersedes #324 and #331