### PR TITLE
kafka 3.5.1 w/ confluent 3.4.1

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,7 +1,7 @@
 import Dependencies._
 
 ThisBuild / parallelExecution := false
-ThisBuild / versionScheme := Some("semver-spec")
+ThisBuild / versionScheme     := Some("semver-spec")
 
 lazy val compileSettings = Seq(
   Compile / compile := (Compile / compile)

--- a/embedded-kafka-schema-registry/src/main/scala/kafka/utils/ShutdownableThread.scala
+++ b/embedded-kafka-schema-registry/src/main/scala/kafka/utils/ShutdownableThread.scala
@@ -1,0 +1,121 @@
+/**
+  * Licensed to the Apache Software Foundation (ASF) under one or more
+  * contributor license agreements. See the NOTICE file distributed with this
+  * work for additional information regarding copyright ownership. The ASF
+  * licenses this file to You under the Apache License, Version 2.0 (the
+  * "License"); you may not use this file except in compliance with the License.
+  * You may obtain a copy of the License at
+  *
+  * http://www.apache.org/licenses/LICENSE-2.0
+  *
+  * Unless required by applicable law or agreed to in writing, software
+  * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+  * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+  * License for the specific language governing permissions and limitations
+  * under the License.
+  */
+
+package kafka.utils
+
+import java.util.concurrent.{CountDownLatch, TimeUnit}
+
+import org.apache.kafka.common.internals.FatalExitError
+
+abstract class ShutdownableThread(
+    val name: String,
+    val isInterruptible: Boolean = true
+) extends Thread(name)
+    with Logging {
+  this.setDaemon(false)
+  this.logIdent = "[" + name + "]: "
+  private val shutdownInitiated            = new CountDownLatch(1)
+  private val shutdownComplete             = new CountDownLatch(1)
+  @volatile private var isStarted: Boolean = false
+
+  def shutdown(): Unit = {
+    initiateShutdown()
+    awaitShutdown()
+  }
+
+  def isShutdownInitiated: Boolean = shutdownInitiated.getCount == 0
+
+  def isShutdownComplete: Boolean = shutdownComplete.getCount == 0
+
+  /**
+    * @return
+    *   true if there has been an unexpected error and the thread shut down
+    */
+  // mind that run() might set both when we're shutting down the broker
+  // but the return value of this function at that point wouldn't matter
+  def isThreadFailed: Boolean = isShutdownComplete && !isShutdownInitiated
+
+  def initiateShutdown(): Boolean = {
+    this.synchronized {
+      if (isRunning) {
+        info("Shutting down")
+        shutdownInitiated.countDown()
+        if (isInterruptible)
+          interrupt()
+        true
+      } else
+        false
+    }
+  }
+
+  /**
+    * After calling initiateShutdown(), use this API to wait until the shutdown
+    * is complete
+    */
+  def awaitShutdown(): Unit = {
+    if (!isShutdownInitiated)
+      throw new IllegalStateException(
+        "initiateShutdown() was not called before awaitShutdown()"
+      )
+    else {
+      if (isStarted)
+        shutdownComplete.await()
+      info("Shutdown completed")
+    }
+  }
+
+  /**
+    * Causes the current thread to wait until the shutdown is initiated, or the
+    * specified waiting time elapses.
+    *
+    * @param timeout
+    * @param unit
+    */
+  def pause(timeout: Long, unit: TimeUnit): Unit = {
+    if (shutdownInitiated.await(timeout, unit))
+      trace("shutdownInitiated latch count reached zero. Shutdown called.")
+  }
+
+  /**
+    * This method is repeatedly invoked until the thread shuts down or this
+    * method throws an exception
+    */
+  def doWork(): Unit
+
+  override def run(): Unit = {
+    isStarted = true
+    info("Starting")
+    try {
+      while (isRunning)
+        doWork()
+    } catch {
+      case e: FatalExitError =>
+        shutdownInitiated.countDown()
+        shutdownComplete.countDown()
+        info("Stopped")
+        Exit.exit(e.statusCode())
+      case e: Throwable =>
+        if (isRunning)
+          error("Error due to", e)
+    } finally {
+      shutdownComplete.countDown()
+    }
+    info("Stopped")
+  }
+
+  def isRunning: Boolean = !isShutdownInitiated
+}

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -14,7 +14,7 @@ object Dependencies {
     val Scala3            = "3.3.0"
     val Scala213          = "2.13.11"
     val Scala212          = "2.12.18"
-    val EmbeddedKafka     = "3.4.1"
+    val EmbeddedKafka     = "3.5.1"
     val ConfluentPlatform = "7.4.1"
     val Slf4j             = "1.7.36"
     val ScalaTest         = "3.2.16"


### PR DESCRIPTION
This should supersede https://github.com/embeddedkafka/embedded-kafka-schema-registry/pull/417

This PR addresses the breaking change introduced with Kafka 3.5.0 [here](https://issues.apache.org/jira/browse/KAFKA-14706), i.e. ShutdownableThread being moved from `kafka.utils` package to `org.apache.kafka.utils` package, thus causing NoClassDefFound errors at runtime when KafkaStoreReaderThread was initiated (https://github.com/confluentinc/schema-registry/blob/0bcf6299a01babc336dbe487d6179ab3cfc39500/core/src/main/java/io/confluent/kafka/schemaregistry/storage/KafkaStoreReaderThread.java#L63), which is what you see in the Steward's PR.

Whether you want to release an embedded-kafka-schema-registry based on current CP (7.4.1) and current Kafka (3.5.1) or you'd rather wait for CP 7.5.x I am not sure, but I do see some value in releasing this.

Goes w/o saying that once CP comes out with 7.5 it most likely will cater for this breaking change directly so the added file under `kafka.utils` namespace can and should be removed.