### PR TITLE
bump Kafka and Confluent to v3.8.0 and v7.8.0 respectively

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -14,8 +14,8 @@ object Dependencies {
     val Scala3            = "3.3.4"
     val Scala213          = "2.13.15"
     val Scala212          = "2.12.20"
-    val EmbeddedKafka     = "3.7.1.1"
-    val ConfluentPlatform = "7.7.2"
+    val EmbeddedKafka     = "3.8.0"
+    val ConfluentPlatform = "7.8.0"
     val Slf4j             = "1.7.36"
     val ScalaTest         = "3.2.19"
   }


### PR DESCRIPTION
Supersedes #484 and #504