### PR TITLE
🧹 chore: use Java 17

### DIFF
--- a/.github/workflows/coverage-report.yml
+++ b/.github/workflows/coverage-report.yml
@@ -13,7 +13,7 @@ jobs:
     - uses: actions/setup-java@v4
       with:
         distribution: 'temurin'
-        java-version: 8
+        java-version: 17
         cache: 'sbt'
     - uses: sbt/setup-sbt@v1
     - name: Compile

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,7 +14,7 @@ jobs:
     - uses: actions/setup-java@v4
       with:
         distribution: 'temurin'
-        java-version: 8
+        java-version: 17
         cache: 'sbt'
     - uses: sbt/setup-sbt@v1
     - name: Publish artifacts

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,7 +13,7 @@ jobs:
     - uses: actions/setup-java@v4
       with:
         distribution: 'temurin'
-        java-version: 8
+        java-version: 17
         cache: 'sbt'
     - uses: sbt/setup-sbt@v1
     - name: Check formatting

--- a/README.md
+++ b/README.md
@@ -13,11 +13,16 @@ Relies on the [embedded-kafka](https://github.com/embeddedkafka/embedded-kafka) 
 
 ## Version compatibility matrix
 
-embedded-kafka-schema-registry is available on Maven Central, compiled for Scala 2.12, 2.13 and Scala 3 (since v7.4.0).
-
-Support for Scala 2.11 was dropped by Apache in Kafka v2.5.0.
+The library available on Maven Central.
 
 Versions match the version of Confluent Schema Registry they're built against.
+
+| embedded-kafka-schema-registry version | Confluent Schema Registry version | embedded-kafka & Kafka Kafka version | Scala versions  | Java version |
+|----------------------------------------|-----------------------------------|--------------------------------------|-----------------|--------------|
+| 7.9.1                                  | 7.9.1                             | 3.9.x                                | 2,12, 2.13, 3.3 | 17+          |
+| 7.9.0                                  | 7.9.0                             | 3.9.x                                | 2,12, 2.13, 3.3 | 8+           |
+| 7.8.0                                  | 7.8.0                             | 3.8.x                                | 2,12, 2.13, 3.3 | 8+           |
+| 7.7.0                                  | 7.7.0                             | 3.7.x                                | 2,12, 2.13, 3.3 | 8+           |
 
 ## Important known limitation (prior to Kafka v2.8.0)
 


### PR DESCRIPTION
The first motivation for this was to upgrade to Java 17 to get rid of errors during publication (https://github.com/embeddedkafka/embedded-kafka-schema-registry/actions/runs/15062020473/job/42383146604):

```
2025-05-16 19:26:10.233Z error [Sonatype] [GENERIC_ERROR] java/net/http/HttpTimeoutException  - (Sonatype.scala:494)
[info] welcome to sbt 1.10.11 (Temurin Java 1.8.0_452)
[info] loading settings for project embedded-kafka-schema-registry-build from plugins.sbt...
[info] loading project definition from /home/runner/work/embedded-kafka-schema-registry/embedded-kafka-schema-registry/project
[info] loading settings for project root from build.sbt...
[info] set current project to embedded-kafka-schema-registry-root (in build file:/home/runner/work/embedded-kafka-schema-registry/embedded-kafka-schema-registry/)
[warn] there's a key that's not used by any other settings/tasks:
[warn]  
[warn] * ThisBuild / parallelExecution
[warn]   +- /home/runner/work/embedded-kafka-schema-registry/embedded-kafka-schema-registry/build.sbt:4
[warn]  
[warn] note: a setting might still be used by a command; to exclude a key from this `lintUnused` check
[warn] either append it to `Global / excludeLintKeys` or call .withRank(KeyRanks.Invisible) on the key
2025-05-16 19:26:17.498Z  warn [SonatypeClient] Disabled http client logging as Java version 1.8.0_452 is no longer supported. Please use Java 17 or later.  - (SonatypeClient.scala:66)
```

~~But I realized, this project had not been upgraded to latest embedded-kafka (4.x), so I did both at once.~~